### PR TITLE
Version 0.4 updates

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -19,11 +19,11 @@ An alignment can be viewed as a hypergraph where each hyperedge consists of:
 
  * an alignment type
  * references (with additional structure if the type is directional)
- * who is responsible for the alignment (possibly a computer  program)
+ * who is responsible for the alignment (possibly a computer program)
  * when the alignment was done (timestamp)
  * other optional information about the alignment (such as confidence and curation status)
 
-As described below, the format allows  hoisting of repeated information to a higher level although ultimately a file in this format can be processed as a flat collection of alignment records.
+As described below, the format allows hoisting of repeated information to a higher level although ultimately a file in this format can be processed as a flat collection of alignment records.
 
 ## Information Model
 
@@ -243,7 +243,7 @@ description: the most generic way of relating units in a directed way
 alignment type: `translation`
 roles: `source`, `target`
 description: `target` is a translation of `source`
-    
+
 And an example from a broader use case of linguistic annotation: 
 
 alignment type: `anaphora`

--- a/spec.md
+++ b/spec.md
@@ -8,6 +8,7 @@ Version 0.2    2023-09-19
 Version 0.2.1  2023-09-25
 Version 0.3    2023-10-02
 Version 0.3.1  2024-02-21
+Version 0.4    2024-08-21
 ```
 
 ## Introduction

--- a/spec.md
+++ b/spec.md
@@ -51,7 +51,7 @@ This specification describes a JSON serialization although other serializations 
 
 An alignment record with roles:
 
-```
+```json
 {
     "type": "translation",
     "source": <reference unit 1>,
@@ -64,7 +64,7 @@ An alignment record with roles:
 
 An alignment record without unit roles, or with unit roles hoisted:
 
-```
+```json
 { 
     "type": "translation",
     "references": [<reference unit 1>, <reference unit 2>],
@@ -76,13 +76,13 @@ An alignment record without unit roles, or with unit roles hoisted:
 
 Without hoisting, a full reference unit might look like:
 
-```
+```json
 { "scheme": "...", "docid": "...", "selectors": ["selector1", "selector2"] }
 ```
 
 but in practice, the `scheme` and `docid` are hoisted and just the selector or list of selectors included:
 
-```
+```json
 ["selector1", "selector2"]
 ```
 
@@ -92,7 +92,7 @@ Alignment records are grouped in an **alignment group** and all information in a
 
 Here the alignment type and creator have been hoisted:
 
-```
+```json
 { 
     "type": "translation",
     "meta": {
@@ -109,7 +109,7 @@ Here the alignment type and creator have been hoisted:
 
 The unit roles can be hoisted by listing the roles at the group level and then giving reference units positionally in a `references` property.
 
-```
+```json
 {
     "type": "translation",
     "meta": {
@@ -126,7 +126,7 @@ The unit roles can be hoisted by listing the roles at the group level and then g
 
 Here the reference scheme and document identifiers have also been hoisted:
 
-```
+```json
 {
     "type": "translation",
     "meta": {
@@ -150,7 +150,7 @@ Here the reference scheme and document identifiers have also been hoisted:
 
 This is equivalent to:
 
-```
+```json
 { 
     "records": [
         {
@@ -182,7 +182,7 @@ The top-level format consists of a format declaration, version number, and then 
 
 With groups:
 
-```
+```json
 {
     "format": "alignment",
     "version": "0.3",
@@ -195,7 +195,7 @@ With groups:
 ```
 Without groups:
 
-```
+```json
 {
     "format": "alignment",
     "version": "0.3",
@@ -223,7 +223,7 @@ The following are examples.
 
 The (tentatively named) `BCVWP` scheme uses a bible version as `docid` and an 11-character `BBCCCVVVWWWP` string according to the GrapeCity / Clear-Bible data, e.g.
 
-```
+```json
 { "scheme": "BCVWP", "docid": "NA27", "selectors": ["410040030011"] }
 ```
 
@@ -231,13 +231,13 @@ refers to the first word, Ἀκούετε in Mark 4.3 in the NA27.
 
 Another tentative scheme could be one that takes a filename as the `docid` and a token offset assuming whitespace tokenization:
 
-```
+```json
 { "scheme": "ws-token", "docid": "mydoc.txt", "selectors": ["37"] }
 ```
 
 Yet another tentative scheme could be one that takes a filename as the `docid` and character offset start and end assuming Unicode NFC normalization: 
 
-```
+```json
 { "scheme": "nfc-char", "docid": "mydoc.txt", "selectors": ["513-520"] } 
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -27,9 +27,11 @@ As described below, the format allows  hoisting of repeated information to a hig
 
 ## Information Model
 
-A **reference** is a combination of a **reference scheme**, a **document identifier**, and a **reference selector**.
+A **reference** is a combination of a **reference scheme**, an optional **document identifier**, and a **reference selector**.
 
 <small>It is envisaged that some reference schemes will identify an existing tokenization of the document and others will merely indicate the tokenization scheme to be applied at processing time to the document.</small>
+
+<small>The documentation identifier is usually included but there are some cases where the alignment is not with a text but just with some referencing scheme (e.g. an audio timecode range might be aligned to a verse number without there being a transcript document). In such cases, a documentation identifier can be omitted.</small>
 
 As a whole, a reference must allow one to unambiguously identify a citable object (usually a word token, but optionally a smaller or larger unit). The separation of these three components allows the reference scheme and document identifier to be hoisted and only the reference selection included in each record.
 

--- a/spec.md
+++ b/spec.md
@@ -180,9 +180,7 @@ Note that `meta` properties that have been hoisted are merged with those remaini
 
 ### Top-Level Format
 
-The top-level format consists of a format declaration, version number, and then either a list of alignment groups or, if no hoisting has been performed, a list of alignment records.
-
-With groups:
+The top-level format consists of a format declaration, version number, and a list of alignment groups:
 
 ```json
 {
@@ -192,19 +190,6 @@ With groups:
         <group1>,
         <group2>,
         <group3>
-    ]
-}
-```
-Without groups:
-
-```json
-{
-    "format": "alignment",
-    "version": "0.3",
-    "records": [
-        <record1>,
-        <record2>,
-        ...
     ]
 }
 ```

--- a/spec.md
+++ b/spec.md
@@ -185,7 +185,7 @@ The top-level format consists of a format declaration, version number, and a lis
 ```json
 {
     "format": "alignment",
-    "version": "0.3",
+    "version": "0.4",
     "groups": [
         <group1>,
         <group2>,


### PR DESCRIPTION
- `docid` is now options (#1)
- groups are now required (#2)
- code blocks are now styled as JSON (#3)
